### PR TITLE
Fixed a bug causing item ids reset on the launch of Minecraft

### DIFF
--- a/src/main/java/adudecalledleo/dontdropit/config/ModConfig.java
+++ b/src/main/java/adudecalledleo/dontdropit/config/ModConfig.java
@@ -65,10 +65,10 @@ public class ModConfig implements ConfigData {
         public boolean drawOverlay = true;
         @ConfigEntry.Gui.PrefixText
         @ConfigEntry.Gui.Tooltip
-        public List<String> items = getRareItemIds();
+        public List<String> items;
         @ConfigEntry.Gui.PrefixText
         @ConfigEntry.Gui.Tooltip
-        public List<String> enchantments = getEnchantmentIds();
+        public List<String> enchantments;
         @ConfigEntry.Gui.Tooltip(count = 3)
         public boolean enchIgnoreInvalidTargets = true;
         @ConfigEntry.Gui.PrefixText
@@ -97,6 +97,10 @@ public class ModConfig implements ConfigData {
         }
 
         void postLoad() {
+            if(items == null)
+                items =  getRareItemIds();
+            if(enchantments == null)
+                enchantments = getEnchantmentIds();
             items = init(items);
             enchantments = init(enchantments);
             tags = init(tags);


### PR DESCRIPTION
**Items & Enchantments couldn't get values from the config because they already had default values.**
I made default values to be assigned only when it's neccessary (e.g. there's no config file).
<sub>I play on 1.17 and that's why I wanted to fix this :)</sub>